### PR TITLE
handle errors when fetching credentials or retrieving documents

### DIFF
--- a/Sources/Presentation/UI/CredentialSelection/CredentialSelectionView.swift
+++ b/Sources/Presentation/UI/CredentialSelection/CredentialSelectionView.swift
@@ -52,9 +52,8 @@ struct CredentialSelectionView<Router: RouterGraph>: View {
         }
       }
     }
-    .task {
-      await viewModel.fetchCredentials()
-      await viewModel.getDocument()
+    .onAppear {
+      viewModel.performDataLoading()
     }
     .confirmationDialog(
       title: localization.get(with: .cancelSigningProcessTitle),


### PR DESCRIPTION
# Description of changes
Before, we showed the credentials view when the fetch credentials request failed, but the get document request succeeded.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other fix (maintenance or house-keeping)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test suite run successfully
- [ ] Added Tests ()

# Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the readme
- [x] My changes generate no new warnings
- [ ] I have added unit tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have checked that my views are *accessible*
- [x] I have checked that my strings are *localized* where applicable
